### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "mikey179/vfsStream": "~1",
-        "phpunit/phpunit": "4.6.*",
+        "phpunit/phpunit": "~4.8.35",
         "satooshi/php-coveralls": "dev-master"
     },
     "autoload": {

--- a/google/appengine/api/search/SearchProtoTest.php
+++ b/google/appengine/api/search/SearchProtoTest.php
@@ -17,11 +17,11 @@
 namespace google\appengine\api\search;
 
 use \google\appengine\IndexDocumentRequest;
+use PHPUnit\Framework\TestCase;
 
-class SearchProtoTest extends\PHPUnit_Framework_TestCase {
+class SearchProtoTest extends TestCase {
   public function testIndexSpecInstantiation() {
     $request = new IndexDocumentRequest();
     $this->assertEquals("", $request->serializePartialToString());
   }
 }
-

--- a/google/appengine/datastore/DatastoreProtoTest.php
+++ b/google/appengine/datastore/DatastoreProtoTest.php
@@ -19,11 +19,11 @@ namespace google\appengine\datastore;
 require_once 'google/appengine/datastore/datastore_v3_pb.php';
 
 use \google\appengine_datastore_v3\Transaction;
+use PHPUnit\Framework\TestCase;
 
-class DatastoreProtoTest extends\PHPUnit_Framework_TestCase {
+class DatastoreProtoTest extends TestCase {
   public function testTransactionInstantiation() {
     $transaction = new Transaction();
     $this->assertEquals("", $transaction->serializePartialToString());
   }
 }
-

--- a/google/appengine/datastore/DatastoreV4ProtoTest.php
+++ b/google/appengine/datastore/DatastoreV4ProtoTest.php
@@ -19,8 +19,9 @@ namespace google\appengine\datastore;
 require_once 'google/appengine/datastore/datastore_v4_pb.php';
 
 use \google\appengine\datastore\v4\Error\ErrorCode;
+use PHPUnit\Framework\TestCase;
 
-class DatastoreV4ProtoTest extends\PHPUnit_Framework_TestCase {
+class DatastoreV4ProtoTest extends TestCase {
   public function testTrivial() {
     $this->assertEquals(1, ErrorCode::BAD_REQUEST);
   }

--- a/google/appengine/ext/remote_api/RemoteApiProtoTest.php
+++ b/google/appengine/ext/remote_api/RemoteApiProtoTest.php
@@ -19,13 +19,13 @@ namespace google\appengine\ext\remote_api;
 require_once 'google/appengine/ext/remote_api/remote_api_pb.php';
 
 use \google\appengine\ext\remote_api\Request;
+use PHPUnit\Framework\TestCase;
 
 # TODO: delete this test when we finalize the layout of the SDK
 
-class RemoteApiProtoTest extends\PHPUnit_Framework_TestCase {
+class RemoteApiProtoTest extends TestCase {
   public function testRequestInstantiation() {
     $req = new Request();
     $this->assertEquals("", $req->serializePartialToString());
   }
 }
-

--- a/google/appengine/ext/session/MemcacheSessionHandlerTest.php
+++ b/google/appengine/ext/session/MemcacheSessionHandlerTest.php
@@ -22,9 +22,11 @@
 
 namespace google\appengine\ext\session;
 
+use PHPUnit\Framework\TestCase;
+
 require_once 'google/appengine/ext/session/MemcacheSessionHandler.php';
 
-class MemcacheSessionHandlerTest extends \PHPUnit_Framework_TestCase {
+class MemcacheSessionHandlerTest extends TestCase {
 
   public function testSession() {
     $stub = $this->getMock('MemcacheContainer', array('close', 'get', 'set',

--- a/google/appengine/runtime/ApiProxyTest.php
+++ b/google/appengine/runtime/ApiProxyTest.php
@@ -35,6 +35,7 @@ require_once 'google/appengine/runtime/RPCFailedError.php';
 use google\appengine\base\VoidProto;
 use google\appengine\runtime\ApiProxyBase;
 use google\appengine\runtime\RealApiProxy;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Mocked make_call function
@@ -54,7 +55,7 @@ function make_call($package,
 /**
  * Unittest for ApiProxy class.
  */
-class ApiProxyTest extends \PHPUnit_Framework_TestCase {
+class ApiProxyTest extends TestCase {
 
   /**
    * Checks that an expected exception corresponds to a

--- a/google/appengine/runtime/DirectUploadHandlerTest.php
+++ b/google/appengine/runtime/DirectUploadHandlerTest.php
@@ -16,7 +16,9 @@
  */
 namespace google\appengine\runtime;
 
-class DirectUploadHandlerTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class DirectUploadHandlerTest extends TestCase {
   public static function setUpBeforeClass() {
     VirtualFileSystem::getInstance()->initialize();
   }

--- a/google/appengine/runtime/GlobTest.php
+++ b/google/appengine/runtime/GlobTest.php
@@ -17,8 +17,9 @@
 namespace google\appengine\runtime;
 
 use google\appengine\testing\TestUtils;
+use PHPUnit\Framework\TestCase;
 
-class GlobTest extends \PHPUnit_Framework_TestCase {
+class GlobTest extends TestCase {
 
   protected function tearDown() {
     if (!empty($GLOBALS['opendir'])) {

--- a/google/appengine/runtime/UnlinkUploadsTest.php
+++ b/google/appengine/runtime/UnlinkUploadsTest.php
@@ -17,8 +17,9 @@
 namespace google\appengine\runtime;
 
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 
-class UnlinkUploadsTest extends \PHPUnit_Framework_TestCase {
+class UnlinkUploadsTest extends TestCase {
   protected $files;
 
   protected function setUp() {

--- a/google/appengine/runtime/VmApiProxyTest.php
+++ b/google/appengine/runtime/VmApiProxyTest.php
@@ -27,7 +27,7 @@ use google\appengine\SignForAppRequest;
 use google\appengine\SignForAppResponse;
 use google\appengine\runtime\ApiProxy;
 use google\appengine\runtime\ApplicationError;
-
+use PHPUnit\Framework\TestCase;
 
 class ValueUnexpectedException extends \Exception {
   public function __construct($expected, $actual) {
@@ -114,7 +114,7 @@ class MockHttpStream {
   }
 }
 
-class VmAPiProxyTest extends \PHPUnit_Framework_TestCase {
+class VmAPiProxyTest extends TestCase {
   const PACKAGE_NAME = "TestPackage";
   const CALL_NAME = "TestCall";
 
@@ -396,4 +396,3 @@ class VmAPiProxyTest extends \PHPUnit_Framework_TestCase {
     putenv(VmApiProxy::DEV_TICKET_HEADER);
   }
 }
-

--- a/google/appengine/testing/ApiProxyTestBase.php
+++ b/google/appengine/testing/ApiProxyTestBase.php
@@ -16,10 +16,12 @@
  */
 namespace google\appengine\testing;
 
+use PHPUnit\Framework\TestCase;
+
 require_once 'google/appengine/testing/ApiCallArguments.php';
 require_once 'google/appengine/testing/ApiProxyMock.php';
 
-class ApiProxyTestBase extends\PHPUnit_Framework_TestCase {
+class ApiProxyTestBase extends TestCase {
   protected function setUp() {
     $this->apiProxyMock = new ApiProxyMock();
     $this->apiProxyMock->init($this);
@@ -29,4 +31,3 @@ class ApiProxyTestBase extends\PHPUnit_Framework_TestCase {
     $this->apiProxyMock->verify();
   }
 }
-

--- a/google/appengine/util/array_util_test.php
+++ b/google/appengine/util/array_util_test.php
@@ -17,8 +17,9 @@
 namespace google\appengine\util;
 
 use google\appengine\util\ArrayUtil;
+use PHPUnit\Framework\TestCase;
 
-class ArrayUtilTest extends \PHPUnit_Framework_TestCase {
+class ArrayUtilTest extends TestCase {
 
   private $merge_fn = "google\appengine\util\ArrayUtil::arrayMergeIgnoreCase";
   /**


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.