### PR TITLE
Make CloudStorageTools::createUploadUrl compatible with PHP7

### DIFF
--- a/google/appengine/api/cloud_storage/CloudStorageTools.php
+++ b/google/appengine/api/cloud_storage/CloudStorageTools.php
@@ -944,6 +944,7 @@ final class CloudStorageTools {
   private static function getUploadMaxFileSizeInBytes() {
     $val = trim(ini_get('upload_max_filesize'));
     $unit = strtolower(substr($val, -1));
+    $val = substr($val, 0, -1);
     switch ($unit) {
       case 'g':
         $val *= 1024;


### PR DESCRIPTION
`createUploadUrl` calls `getUploadMaxFileSizeInBytes`, which does the following operation on a mostly-numeric string:

`$val *= 1024`

In PHP5, this works fine, because non-numeric values are stripped from the end.

In PHP7, a warning is issued which states `A non well formed numeric value encountered`.

The value has a final non-numeric character which can be stripped to prevent this warning.

This will continue to function in PHP5 as well.

Fixes #10