### PR TITLE
chore: update require-dev to use php-coveralls/php-coveralls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "mikey179/vfsStream": "~1",
         "phpunit/phpunit": "4.6.*",
-        "satooshi/php-coveralls": "dev-master"
+        "php-coveralls/php-coveralls": "dev-master"
     },
     "autoload": {
         "files": ["google/appengine/runtime/autoloader.php"]

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "mikey179/vfsStream": "~1",
+        "mikey179/vfsstream": "~1",
         "phpunit/phpunit": "4.6.*",
         "php-coveralls/php-coveralls": "dev-master"
     },


### PR DESCRIPTION
The package satooshi/php-coveralls is abandoned and users are recommended to use php-coveralls/php-coveralls instead [0].

[0] https://packagist.org/packages/satooshi/php-coveralls