### PR TITLE
Update env variables in AppIdentity

### DIFF
--- a/src/Api/AppIdentity/AppIdentityService.php
+++ b/src/Api/AppIdentity/AppIdentityService.php
@@ -245,12 +245,9 @@ final class AppIdentityService {
    * @return string The application id of the app.
    */
   public static function getApplicationId() {
-    $app_id = getenv("APPLICATION_ID");
-    $psep = strpos($app_id, self::PARTITION_SEPARATOR);
-    if ($psep > 0) {
-      $app_id = substr($app_id, $psep + 1);
-    }
-    return $app_id;
+    $appid_arr = explode('~', getenv('GAE_APPLICATION'));
+    $appid = $appid_arr[1];
+    return $appid;
   }
 
   /**
@@ -260,7 +257,7 @@ final class AppIdentityService {
    * application, or FALSE if the call failed.
    */
   public static function getDefaultVersionHostname() {
-    return getenv("DEFAULT_VERSION_HOSTNAME");
+    return getenv('HTTP_X_APPENGINE_DEFAULT_VERSION_HOSTNAME');
   }
 
   /**

--- a/tests/Api/AppIdentity/AppIdentityServiceTest.php
+++ b/tests/Api/AppIdentity/AppIdentityServiceTest.php
@@ -376,7 +376,7 @@ class AppIdentityServiceTest extends ApiProxyTestBase {
     $this->assertEquals("simple-app-id",
                         AppIdentityService::getApplicationId());
 
-    putenv("GAE_APPLICATION=domain.com:domain-app-id");
+    putenv("GAE_APPLICATION=part~domain.com:domain-app-id");
     $this->assertEquals("domain.com:domain-app-id",
                         AppIdentityService::getApplicationId());
 

--- a/tests/Api/AppIdentity/AppIdentityServiceTest.php
+++ b/tests/Api/AppIdentity/AppIdentityServiceTest.php
@@ -372,25 +372,25 @@ class AppIdentityServiceTest extends ApiProxyTestBase {
   }
 
   public function testGetApplicationId() {
-    putenv("APPLICATION_ID=simple-app-id");
+    putenv("GAE_APPLICATION=simple-app-id");
     $this->assertEquals("simple-app-id",
                         AppIdentityService::getApplicationId());
 
-    putenv("APPLICATION_ID=domain.com:domain-app-id");
+    putenv("GAE_APPLICATION=domain.com:domain-app-id");
     $this->assertEquals("domain.com:domain-app-id",
                         AppIdentityService::getApplicationId());
 
-    putenv("APPLICATION_ID=part~partition-app-id");
+    putenv("GAE_APPLICATION=part~partition-app-id");
     $this->assertEquals("partition-app-id",
                         AppIdentityService::getApplicationId());
 
-    putenv("APPLICATION_ID=part~domain.com:display");
+    putenv("GAE_APPLICATION=part~domain.com:display");
     $this->assertEquals("domain.com:display",
                         AppIdentityService::getApplicationId());
   }
 
   public function testGetDefaultVersionHostname() {
-    putenv("DEFAULT_VERSION_HOSTNAME=my-app.appspot.com");
+    putenv("HTTP_X_APPENGINE_DEFAULT_VERSION_HOSTNAME=my-app.appspot.com");
     $this->assertEquals("my-app.appspot.com",
                         AppIdentityService::getDefaultVersionHostname());
   }

--- a/tests/Api/AppIdentity/AppIdentityServiceTest.php
+++ b/tests/Api/AppIdentity/AppIdentityServiceTest.php
@@ -372,7 +372,7 @@ class AppIdentityServiceTest extends ApiProxyTestBase {
   }
 
   public function testGetApplicationId() {
-    putenv("GAE_APPLICATION=simple-app-id");
+    putenv("GAE_APPLICATION=part~simple-app-id");
     $this->assertEquals("simple-app-id",
                         AppIdentityService::getApplicationId());
 


### PR DESCRIPTION
Update env variables to use PHP7 compatible variables. 
PHP7 Variables: https://cloud.google.com/appengine/docs/standard/php7/runtime#environment_variables
PHP5 Variables: https://cloud.google.com/appengine/docs/standard/php/runtime#environment_variables