### PR TITLE
urlfetch iterator fix

### DIFF
--- a/src/Api/UrlFetch/UrlFetchStream.php
+++ b/src/Api/UrlFetch/UrlFetchStream.php
@@ -53,7 +53,7 @@ class UrlFetchStream implements IteratorAggregate, ArrayAccess
      */
 
     /* IteratorAggregate */
-    public function getIterator(): Traversable 
+    public function getIterator(): iterable
     {
         return new ArrayIterator($this->responseHeaders);
     }


### PR DESCRIPTION
Type hinting of "Traversable" in php is illegal and it should be replaced by "iterable". Iterable was introduced in Php 7.1 and was created to type hint an object which implements the Traverable interface. For more information please see: https://www.php.net/manual/en/language.types.iterable