### PR TITLE
Update Modules API

### DIFF
--- a/src/Api/Modules/ModulesService.php
+++ b/src/Api/Modules/ModulesService.php
@@ -67,7 +67,7 @@ final class ModulesService {
    * will return "module5".
    */
   public static function getCurrentModuleName() {
-    return $_SERVER['CURRENT_MODULE_ID'];
+    return $_SERVER['GAE_SERVICE'];
   }
 
   /**
@@ -91,7 +91,7 @@ final class ModulesService {
    * "00c61b117c7f7fd0ce9e1325a04b8f0df30deaaf").
    */
   public static function getCurrentInstanceId() {
-    return $_SERVER['INSTANCE_ID'];
+    return $_SERVER['GAE_INSTANCE'];
   }
 
   /**

--- a/src/Api/Modules/ModulesService.php
+++ b/src/Api/Modules/ModulesService.php
@@ -78,7 +78,7 @@ final class ModulesService {
    * will return "v1".
    */
   public static function getCurrentVersionName() {
-    return explode('.', $_SERVER['CURRENT_VERSION_ID'])[0];
+    return explode('.', $_SERVER['GAE_VERSION'])[0];
   }
 
   /**

--- a/tests/Api/Modules/ModulesServiceTest.php
+++ b/tests/Api/Modules/ModulesServiceTest.php
@@ -54,24 +54,24 @@ class ModulesTest extends ApiProxyTestBase {
   }
 
   public function testGetCurrentModuleNameWithDefaultModule() {
-    $_SERVER['CURRENT_MODULE_ID'] = 'default';
-    $_SERVER['CURRENT_VERSION_ID'] = 'v1.123';
+    $_SERVER['GAE_SERVICE'] = 'default';
+    $_SERVER['GAE_VERSION'] = 'v1.123';
     $this->assertEquals('default', ModulesService::getCurrentModuleName());
   }
 
   public function testGetCurrentModuleNameWithNonDefaultModule() {
-    $_SERVER['CURRENT_MODULE_ID'] = 'module1';
-    $_SERVER['CURRENT_VERSION_ID'] = 'v1.123';
+    $_SERVER['GAE_SERVICE'] = 'module1';
+    $_SERVER['GAE_VERSION'] = 'v1.123';
     $this->assertEquals('module1', ModulesService::getCurrentModuleName());
   }
 
   public function testGetCurrentVersionName() {
-    $_SERVER['CURRENT_VERSION_ID'] = 'v1.123';
+    $_SERVER['GAE_VERSION'] = 'v1.123';
     $this->assertEquals('v1', ModulesService::getCurrentVersionName());
   }
 
   public function testGetCurrentInstanceId() {
-    $_SERVER['INSTANCE_ID'] = '123';
+    $_SERVER['GAE_INSTANCE'] = '123';
     $this->assertEquals('123', ModulesService::getCurrentInstanceId());
   }
 


### PR DESCRIPTION
Updating the Modules API to the PHP7 Server keys: https://cloud.google.com/appengine/docs/standard/php7/runtime#special_server_keys