### PR TITLE
docs: update README to acknowledge legacy package status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 [![Packagist](https://poser.pugx.org/google/appengine-php-sdk/v/stable)](https://packagist.org/packages/google/appengine-php-sdk)
 [![License](https://poser.pugx.org/google/appengine-php-sdk/license)](https://packagist.org/packages/google/appengine-php-sdk)
 
+## Legacy Support
+
+This package supports access to legacy bundled services for PHP 5.5 in the App Engine standard environment. To access services available in second-generation runtimes for current versions of PHP, refer to [available legacy bundled services](https://cloud.google.com/appengine/docs/standard/services/overview?tab=php).
+
 ## Description
 
 The Google App Engine PHP SDK is provided for developers that are building
@@ -12,9 +16,3 @@ libraries designed to compose with the App Engine SDK.
 This is a subset of the full App Engine SDK that is available for developers
 that are simply writing applications to run on App Engine. You can download
 the full SDK for developing applications from [here](https://cloud.google.com/appengine/downloads).
-
-Please see API documentation at https://googlecloudplatform.github.io/appengine-php-sdk/2.0.0. Or more generally, https://googlecloudplatform.github.io/appengine-php-sdk/"release-tag-number".
-
-This Gen 2 SDK is currently in private preview. To gain access, please sign up at https://docs.google.com/forms/d/e/1FAIpQLSd1hFLA2UFSYwIMxm9ZI3pwigORZBgjJRH0qrnhtE7nvhhRCQ/viewform.
-
-


### PR DESCRIPTION
Close #104 and close #91 by acknowledging that this package is legacy and not intended for use with non-legacy PHP runtimes.

Recommend marking it *abandoned* on Packagist.org as well as support for developers.